### PR TITLE
COMPVIS-3547

### DIFF
--- a/cvpy/image.py
+++ b/cvpy/image.py
@@ -196,3 +196,39 @@ def fetch_image_array(imdata, n=0, qry='', image='_image_', dim='_dimension_', r
     medical_resolutions = example_rows[res]
     return get_image_array(medical_binaries, medical_dimensions, medical_resolutions, medical_formats, n, ccount)
 
+def fetch_geometry_info(imdata, n=0, qry='', posCol='_position_', oriCol='_orientation_', spaCol='_spacing_', dimCol='_dimension_'):
+
+    '''
+    Fetch geometry information from a CAS table.
+
+    Parameters
+    ----------
+    imdata : CASTable
+        Specifies the SWAT CASTable that contains the image.
+    n : int
+        Specifies the number of images.
+    qry : string
+        Specifies the query.
+    posCol : string
+        Specifies the position column.
+    oriCol : string
+        Specifies the orientation column.
+    spaCol : string
+        Specifies the spacing column.
+    dimCol : string
+        Specifies the dimension column.
+
+    Returns
+    -------
+    :tuple, tuple, tuple
+    '''
+
+    if (qry != ''):
+        example_rows = imdata[[dimCol, posCol, oriCol, spaCol]].query(qry).to_frame(to=n)
+    else:
+        example_rows = imdata[[dimCol, posCol, oriCol, spaCol]].to_frame(to=n)
+    dim = example_rows[dimCol][0]
+    pos = struct.unpack('=%sd'%dim, example_rows[posCol][0][0:dim*8])
+    ori = struct.unpack('=%sd'%(dim*dim), example_rows[oriCol][0][0:dim*dim*8])
+    spa = struct.unpack('=%sd'%dim, example_rows[spaCol][0][0:dim*8])
+    return pos, ori, spa

--- a/cvpy/image.py
+++ b/cvpy/image.py
@@ -74,35 +74,35 @@ def get_image_array_from_row(image_binary, dimension, resolution, myformat, chan
 
     num_cells = np.prod(resolution)
     if (myformat == '32S'):
-        image_array = np.array(struct.unpack('=%si' % num_cells, image_binary[0:4 * num_cells]))
+        image_array = np.array(struct.unpack('=%si' % num_cells, image_binary[0:4 * num_cells])).astype(np.int32)
         image_array = np.reshape(image_array, resolution)
     elif myformat == '32F':
-        image_array = np.array(struct.unpack('=%sf' % num_cells, image_binary[0:4 * num_cells]))
+        image_array = np.array(struct.unpack('=%sf' % num_cells, image_binary[0:4 * num_cells])).astype(np.float32)
         image_array = np.reshape(image_array, resolution)
     elif myformat == '64F':
-        image_array = np.array(struct.unpack('=%sd' % num_cells, image_binary[0:8 * num_cells]))
+        image_array = np.array(struct.unpack('=%sd' % num_cells, image_binary[0:8 * num_cells])).astype(np.float64)
         image_array = np.reshape(image_array, resolution)
     elif myformat == '64U':
-        image_array = np.array(struct.unpack('=%sQ' % num_cells, image_binary[0:8 * num_cells]))
+        image_array = np.array(struct.unpack('=%sQ' % num_cells, image_binary[0:8 * num_cells])).astype(np.uint64)
         image_array = np.reshape(image_array, resolution)
     elif myformat == '16S':
-        image_array = np.array(struct.unpack('=%sh' % num_cells, image_binary[0:2 * num_cells]))
+        image_array = np.array(struct.unpack('=%sh' % num_cells, image_binary[0:2 * num_cells])).astype(np.int16)
         image_array = np.reshape(image_array, resolution)
     elif myformat == '16U':
-        image_array = np.array(struct.unpack('=%sH' % num_cells, image_binary[0:2 * num_cells]))
+        image_array = np.array(struct.unpack('=%sH' % num_cells, image_binary[0:2 * num_cells])).astype(np.uint16)
         image_array = np.reshape(image_array, resolution)
     elif myformat == '8U' and channel_count==3:
-        image_array = np.array(bytearray(image_binary[0:(num_cells*3)]))
+        image_array = np.array(bytearray(image_binary[0:(num_cells*3)])).astype(np.uint8)
         image_array = np.reshape(image_array, (resolution[0], resolution[1], 3))[:, :, 0:3]
         image_array = __reverse(image_array, 2)
     elif myformat == '8S':
-        image_array = np.array(struct.unpack('=%sb' % num_cells, image_binary[0:num_cells]))
+        image_array = np.array(struct.unpack('=%sb' % num_cells, image_binary[0:num_cells])).astype(np.int8)
         image_array = np.reshape(image_array, resolution)
     elif myformat == '8U':
-        image_array = np.array(struct.unpack('=%sB' % num_cells, image_binary[0:num_cells]))
+        image_array = np.array(struct.unpack('=%sB' % num_cells, image_binary[0:num_cells])).astype(np.uint8)
         image_array = np.reshape(image_array, resolution)
     else:
-        image_array = np.array(bytearray(image_binary))
+        image_array = np.array(bytearray(image_binary)).astype(np.uint8)
         image_array = np.reshape(image_array, (resolution[0], resolution[1], 3))
         image_array = __reverse(image_array, 2)
     return image_array
@@ -136,7 +136,6 @@ def get_image_array(image_binaries, dimensions, resolutions, formats, n, channel
     resolution = np.array(struct.unpack('=%sq' % dimension, resolutions[n][0:dimension * 8]))
     resolution = resolution[::-1]
     myformat = formats[n]
-    num_cells = np.prod(resolution)
     return get_image_array_from_row(image_binaries[n], dimension, resolution, myformat, channel_count)
 
 def convert_to_CAS_column(s):
@@ -222,6 +221,10 @@ def fetch_geometry_info(imdata, n=0, qry='', posCol='_position_', oriCol='_orien
     -------
     :tuple, tuple, tuple
     '''
+
+    # Check if geometry info exists in CAS table query before fetching
+    if not {'_position_', '_spacing_', '_orientation_'}.issubset(imdata.columns):
+        return ((), (), ())
 
     if (qry != ''):
         example_rows = imdata[[dimCol, posCol, oriCol, spaCol]].query(qry).to_frame(to=n)

--- a/cvpy/tests/test_image.py
+++ b/cvpy/tests/test_image.py
@@ -24,6 +24,7 @@ import sys
 import numpy as np
 from cvpy.image import *
 
+
 class TestImage(unittest.TestCase):
 
     def test_convert_to_CAS_column(self):
@@ -91,10 +92,49 @@ class TestImage(unittest.TestCase):
         resolution = np.array(struct.unpack('=%sq' % dimension, medicalResolutions[n][0:dimension * 8]))
         resolution = resolution[::-1]
         myformat = medicalFormats[n]
-        num_cells = np.prod(resolution)
         medicalImageArray = get_image_array_from_row(medicalBinaries[n], dimension, resolution, myformat, 1)
 
         self.assertTrue(np.array_equal(medicalImageArray, np.array([[0, 0, 0, 0, 0], [0, 255, 0, 0, 0], [0, 255, 0, 150, 0], [0, 0, 0, 0, 50], [0, 0, 0, 0, 0]])))
+
+    def test_get_image_array_from_row_dtypes(self):
+        test_pass = True
+        width = 2
+
+        # Test all single channel data types
+        img_dtypes = ['32S', '32F', '64F', '64U', '16U', '16S', '8U', '8S']
+        np_dtypes = [np.int32, np.float32, np.float64, np.uint64, np.uint16, np.int16, np.uint8, np.int8, np.uint8]
+        for (img_dtype, np_dtype) in zip(img_dtypes, np_dtypes):
+            image = np.arange(0,width*width).reshape([width,width]).astype(np_dtype)
+            resolution = image.shape[:2]
+            imageArray = get_image_array_from_row(bytes(image), 2, resolution, img_dtype, 1)
+            test_pass = test_pass and np.array_equal(image, imageArray)
+            test_pass = test_pass and (imageArray.dtype == np_dtype)
+
+        # Test all multi-channel data types
+        img_dtypes = ['8U', '']
+        np_dtypes = [np.uint8, np.uint8]
+        for (img_dtype, np_dtype) in zip(img_dtypes, np_dtypes):
+            image = np.arange(0,width*width*3).reshape([width,width,3]).astype(np_dtype)
+            resolution = image.shape[:2]
+            imageArray = get_image_array_from_row(bytes(np.flip(image, 2)), 2, resolution, img_dtype, 3)
+            test_pass = test_pass and np.array_equal(image, imageArray)
+            test_pass = test_pass and (imageArray.dtype == np_dtype)
+
+        self.assertTrue(test_pass)
+
+    def test_fetch_geometry_info_no_geometry(self):
+        self.s = swat.CAS(self.casHost, self.casPort, self.username, self.password)
+        self.s.loadactionset('image')
+        self.s.addcaslib(name='dlib', activeOnAdd=False, path=self.dataPath, dataSource='PATH', subdirectories=True)
+
+        # Load the image
+        image = self.s.CASTable("image", replace=True)
+        self.s.image.loadImages(path='biomedimg/simple.png',
+                                casOut=image,
+                                caslib='dlib',
+                                decode=True)
+
+        self.assertTrue(fetch_geometry_info(image) == ((),(),()))
 
     def test_fetch_geometry_info(self):
         self.s = swat.CAS(self.casHost, self.casPort, self.username, self.password)
@@ -103,16 +143,14 @@ class TestImage(unittest.TestCase):
 
         # Load an image with geometry data
         imgray = self.s.CASTable("imgray", replace=True)
-        self.s.image.loadimages(
-            path="dicomdata/ExpertSegScans/CAESAR007/1",
-            recurse=True,
-            casout=imgray,
-            decode=True,
-            caslib="dlib",
-            addcolumns={"position", "orientation", "spacing"},
-        )
+        self.s.image.loadimages(path="biomedimg/simple.png",
+                                casout=imgray,
+                                decode=True,
+                                caslib="dlib",
+                                addcolumns={"position", "orientation", "spacing"},
+                                )
 
-        self.assertTrue(fetch_geometry_info(imgray) == ((-173.63671875, -290.63671875, -775.5), (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),(0.7265625, 0.7265625, 3.0)))
+        self.assertTrue(fetch_geometry_info(imgray) == ((0, 0), (1.0, 0.0, 0.0, 1.0), (1.0, 1.0)))
 
 if __name__ == '__main__':
     if len(sys.argv) > 1:

--- a/cvpy/tests/test_image.py
+++ b/cvpy/tests/test_image.py
@@ -93,8 +93,26 @@ class TestImage(unittest.TestCase):
         myformat = medicalFormats[n]
         num_cells = np.prod(resolution)
         medicalImageArray = get_image_array_from_row(medicalBinaries[n], dimension, resolution, myformat, 1)
-        
+
         self.assertTrue(np.array_equal(medicalImageArray, np.array([[0, 0, 0, 0, 0], [0, 255, 0, 0, 0], [0, 255, 0, 150, 0], [0, 0, 0, 0, 50], [0, 0, 0, 0, 0]])))
+
+    def test_fetch_geometry_info(self):
+        self.s = swat.CAS(self.casHost, self.casPort, self.username, self.password)
+        self.s.loadactionset('image')
+        self.s.addcaslib(name='dlib', activeOnAdd=False, path=self.dataPath, dataSource='PATH', subdirectories=True)
+
+        # Load an image with geometry data
+        imgray = self.s.CASTable("imgray", replace=True)
+        self.s.image.loadimages(
+            path="dicomdata/ExpertSegScans/CAESAR007/1",
+            recurse=True,
+            casout=imgray,
+            decode=True,
+            caslib="dlib",
+            addcolumns={"position", "orientation", "spacing"},
+        )
+
+        self.assertTrue(fetch_geometry_info(imgray) == ((-173.63671875, -290.63671875, -775.5), (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),(0.7265625, 0.7265625, 3.0)))
 
 if __name__ == '__main__':
     if len(sys.argv) > 1:


### PR DESCRIPTION
This pull request has 2 primary additions / modifications:

1.a. The addition of the function `fetch_geometry_info()` to `image.py`; this function returns a tuple of geometry data ('orientation', 'position', and 'spacing') from a CASTable. If the CASTable does not have geometry data columns the function returns a tuple of empty tuples.
1.b. Unit tests for evaluating `fetch_geometry_info()`. The unit tests check the return values for images with and without geometry data.

2.a. The  `get_image_array_from_row()` function now sets the type of the NumPy array directly. This addition is to insure the data type of the returned NumPy image arrays match the CASTable types (in addition to insuring the types are what we expect it prevents NumPy from using a more memory inefficient data type).
2.b. Added a unit test to check all possible data types in the CASTable -> NumPy array conversion in `get_image_array_from_row()`.

 