### PR TITLE
Updated README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,6 @@ Install VTK, a critical dependency for Mayavi.
 
 Note that a specific version of is VTK used. You can download the wheel file from [here](https://www.lfd.uci.edu/~gohlke/pythonlibs/#vtk).
 
-Install traits, another critical dependency for Mayavi.
-
-`pip install traits‑5.1.2‑cp37‑cp37m‑win_amd64.whl`
-
-Note that a specific version of traits is used. You can download the wheel file from [here](https://www.lfd.uci.edu/~gohlke/pythonlibs/#traits).
-
 Install Mayavi
 
 `pip install mayavi`


### PR DESCRIPTION
Removed instructions to install traits-5.1.2 wheel package because (1) this package is no longer available to download as a compiled wheel and (2) installing the most current Mayavi requires a newer version of traits (6.2.0 the correct version as of now). Allowing Mayavi to install the traits version that it needs has been tested and works.