### PR TITLE
Update Image API doc / Add GitHub workflow to update doc.

### DIFF
--- a/.github/workflows/build-doc-on-push.yml
+++ b/.github/workflows/build-doc-on-push.yml
@@ -1,0 +1,58 @@
+# This workflow updates the documentation.
+# It is intended for two purposes:
+#  1.) Create a preview of the doc that can be reviewed before a pull request.
+#  2.) Keep the documentation in sync with the package at PyPI.
+#
+# To enable a Preview, a contributor must have their fork of CVPy configured to
+# host documentation from their gh-pages branch. For information about that, see
+# https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-from-a-branch
+
+name: Build and Deploy Documentation
+
+on:
+  push:
+    paths:
+      - doc/**
+  workflow_run:
+    workflows: [Publish Package to PyPI]
+    types:
+      - completed
+  workflow_dispatch:
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        # Remove PyQt to avoid Sphinx build error.
+        # I think removing PyQt resolves a conflict between
+        # pip-installed Qt and the Ubuntu VM.
+        run: |
+          python -m pip install --upgrade pip
+          pip install sphinx sphinx_rtd_theme numpydoc ipython
+          pip install .
+          pip uninstall -y PyQt5 PyQt5-Qt5 PyQt5-sip
+      - name: Build the doc
+        run: cd doc && make html && ls build/html && cd ..
+      - name: Commit documentation changes
+        run: |
+          git clone ${{ github.server_url }}/${{ github.repository }} --branch gh-pages --single-branch gh-pages
+          cp -r doc/build/html/* gh-pages/
+          cd gh-pages
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add .
+          git commit -m "Update documentation" -a || true
+          # The above command will fail if no changes were present, so we ignore
+          # the return code.
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          branch: gh-pages
+          directory: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/cvpy/biomedimage/BiomedImage.py
+++ b/cvpy/biomedimage/BiomedImage.py
@@ -64,7 +64,7 @@ class BiomedImage(object):
         Quantify the sphericity for the given component from a CAS table. 
 
         Parameters
-        -----------
+        ----------
         image_table: ImageTable
              Specifies the CAS table that contains the image binaries.
         use_spacing: bool

--- a/cvpy/image/Image.py
+++ b/cvpy/image/Image.py
@@ -280,13 +280,13 @@ class Image(object):
         ''''
         Convert a wide image to a numpy image array.
 
-        Parameters:
+        Parameters
         ----------
         wide_image: bytes buffer
              Specifies the wide image byte buffer
 
-        Returns:
-        ----------
+        Returns
+        -------
         numpy.ndarray
 
         '''

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -44,17 +44,20 @@ CAS Thread Tuner Results
 Image
 -----
 
-.. currentmodule:: cvpy.image
+.. currentmodule:: cvpy.image.Image
 
 .. autosummary::
     :toctree: generated/
 
-    get_image_array_from_row
-    get_image_array
-    convert_to_CAS_column
-    fetch_image_array
-    fetch_geometry_info
-    get_image_array_const_ctype
+    Image
+    Image.convert_to_CAS_column
+    Image.convert_wide_to_numpy
+    Image.fetch_geometry_info
+    Image.fetch_image_array
+    Image.get_image_array_from_row
+    Image.get_image_array
+    Image.get_image_array_const_ctype
+
 
 ImageTable
 ----------

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -13,7 +13,7 @@ Biomedical Images
 .. currentmodule:: cvpy.biomedimage.BiomedImage
     
 .. autosummary::
-    :toctree: generated/
+    :toctree: ../build/generated
 
     BiomedImage
     BiomedImage.quantify_sphericity
@@ -24,7 +24,7 @@ CAS Thread Tuner
 .. currentmodule:: cvpy.utils.CASThreadTuner
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: ../build/generated
 
     CASThreadTuner
     CASThreadTuner.tune_thread_count
@@ -36,7 +36,7 @@ CAS Thread Tuner Results
 .. currentmodule:: cvpy.base.CASThreadTunerResults
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: ../build/generated
 
     CASThreadTunerResults
     CASThreadTunerResults.plot_exec_times
@@ -47,7 +47,7 @@ Image
 .. currentmodule:: cvpy.image.Image
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: ../build/generated
 
     Image
     Image.convert_to_CAS_column
@@ -65,7 +65,7 @@ ImageTable
 .. currentmodule:: cvpy.base.ImageTable
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: ../build/generated
 
     ImageTable
     ImageTable.as_dict
@@ -78,7 +78,7 @@ Visualization Reference
 .. currentmodule:: cvpy.visualization
 
 .. autosummary::
-    :toctree: generated/
+    :toctree: ../build/generated
 
     display_image_slice
     display_3D_image_slices_from_array


### PR DESCRIPTION
Sorry that I muddled two issues together in one pull request. I didn't recognize the dependency of the workflow on the doc API.

There are three changes in this pull request:

1. Update the references in api.rst and edit the Image docstrings to silence the warnings in the doc build.
2. Add a GitHub workflow to build and commit the doc to the gh-pages branch.
3. Update the api.rst so that generated objects are put into the build subdirectory.

Item 3 was partially just a test to confirm that the on-push trigger of the workflow works. (It does.) But it also means that all the doc build artifacts are contained within the doc/build directory instead of being scattered. As an effect `make clean` now wipes out _all_ the artifacts of the doc build.

With the workflow, I intended it to serve two purposes: 
1. Keep the official documentation in sync with the official software release on PyPI. (This my reasoning for triggering the workflow when the "Publish to PyPI" workflow completes.)
2. Spot doc errors before they are merged to main. To do this, the workflow is triggered on push. It builds the doc and commits the changes to the user's gh-pages branch. If they have their fork configured to host the gh-pages branch, we can preview the changes. (I left a reference in the workflow to configure a fork to host the gh-pages branch.)

The job can also be run on demand because that's a nice feature to resolve inevitable hiccups in automation.

I think that we should consider adding "successful doc build" to the contributing guidelines. I'll bring the idea up for discussion at the next round of demos.