### PR TITLE
Fix doc theme issues

### DIFF
--- a/.github/workflows/build-doc-on-push.yml
+++ b/.github/workflows/build-doc-on-push.yml
@@ -37,8 +37,9 @@ jobs:
           pip install sphinx sphinx_rtd_theme numpydoc ipython
           pip install .
           pip uninstall -y PyQt5 PyQt5-Qt5 PyQt5-sip
+          pip list
       - name: Build the doc
-        run: cd doc && make html && ls build/html && cd ..
+        run: cd doc && cat source/conf.py && make html && ls build/html && cd ..
       - name: Commit documentation changes
         run: |
           git clone ${{ github.server_url }}/${{ github.repository }} --branch gh-pages --single-branch gh-pages

--- a/cvpy/image/Image.py
+++ b/cvpy/image/Image.py
@@ -277,7 +277,7 @@ class Image(object):
     @staticmethod
     def convert_wide_to_numpy(wide_image) -> np.ndarray:
 
-        ''''
+        '''
         Convert a wide image to a numpy image array.
 
         Parameters

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -13,7 +13,7 @@ Biomedical Images
 .. currentmodule:: cvpy.biomedimage.BiomedImage
     
 .. autosummary::
-    :toctree: ../build/generated
+    :toctree: generated/
 
     BiomedImage
     BiomedImage.quantify_sphericity
@@ -24,7 +24,7 @@ CAS Thread Tuner
 .. currentmodule:: cvpy.utils.CASThreadTuner
 
 .. autosummary::
-    :toctree: ../build/generated
+    :toctree: generated/
 
     CASThreadTuner
     CASThreadTuner.tune_thread_count
@@ -36,7 +36,7 @@ CAS Thread Tuner Results
 .. currentmodule:: cvpy.base.CASThreadTunerResults
 
 .. autosummary::
-    :toctree: ../build/generated
+    :toctree: generated/
 
     CASThreadTunerResults
     CASThreadTunerResults.plot_exec_times
@@ -47,7 +47,7 @@ Image
 .. currentmodule:: cvpy.image.Image
 
 .. autosummary::
-    :toctree: ../build/generated
+    :toctree: generated/
 
     Image
     Image.convert_to_CAS_column
@@ -65,7 +65,7 @@ ImageTable
 .. currentmodule:: cvpy.base.ImageTable
 
 .. autosummary::
-    :toctree: ../build/generated
+    :toctree: generated/
 
     ImageTable
     ImageTable.as_dict
@@ -78,7 +78,7 @@ Visualization Reference
 .. currentmodule:: cvpy.visualization
 
 .. autosummary::
-    :toctree: ../build/generated
+    :toctree: generated/
 
     display_image_slice
     display_3D_image_slices_from_array

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -145,9 +145,14 @@ import sphinx_rtd_theme  # noqa: E402
 
 html_theme = 'sphinx_rtd_theme'
 
-html_context = {
-    'css_files': ['_static/custom.css'],
-}
+## html_context is deprecated; use html_static_path & css_files instead.
+## https://stackoverflow.com/questions/73220398/sphinx-rtd-theme-not-formatting-correctly-missing-theme-css
+# html_context = {
+#     'css_files': ['_static/custom.css'],
+# }
+
+html_static_path = ['_static']
+html_css_files = ['theme.css']
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Although the doc built correctly in my local environment, the HTML created from the GitHub build failed to link to the proper stylesheets. It turns out that the sphinx-rtd-theme package deprecated the use of html_context. Since my local environment used an older copy than the GitHub VM, it didn't cause any problems.

I'm also undoing the the change that moved where the doc stubs are created. Even though I can change where they are put, sphinx still expects to find them in the default location. When I had moved the location, you could no longer click the API element to get more details. This fixes that.