### PR TITLE
Fix doc build by pinning VTK version.

### DIFF
--- a/.github/workflows/build-doc-on-push.yml
+++ b/.github/workflows/build-doc-on-push.yml
@@ -34,7 +34,7 @@ jobs:
         # pip-installed Qt and the Ubuntu VM.
         run: |
           python -m pip install --upgrade pip
-          pip install sphinx sphinx_rtd_theme numpydoc ipython
+          pip install sphinx sphinx_rtd_theme numpydoc ipython VTK==9.2.0rc2
           pip install .
           pip uninstall -y PyQt5 PyQt5-Qt5 PyQt5-sip
           pip list


### PR DESCRIPTION
@courtneyambrozic , something changed in the latest VTK update that breaks mayavi. I'm pinning the doc build job to the previous working version. I'm not sure that anything needs to be done for the CVPy build, but I wanted to let you know about my findings.

[Here is proof of a successful run.](https://github.com/kybowm/python-cvpy/actions/runs/3266667369)

Am I okay to merge this update?