### PR TITLE
Support float image input for convert_wide_to_numpy()

### DIFF
--- a/cvpy/base/ImageDataType.py
+++ b/cvpy/base/ImageDataType.py
@@ -4,3 +4,7 @@ from enum import Enum
 class ImageDataType(Enum):
     CV_8UC1 = 0
     CV_8UC3 = 16
+    CV_32FC1 = 5
+    CV_32FC3 = 21
+    CV_64FC1 = 6
+    CV_64FC3 = 22

--- a/cvpy/image/Image.py
+++ b/cvpy/image/Image.py
@@ -26,6 +26,7 @@ from warnings import warn
 from swat import CAS, CASTable
 from cvpy.base.ImageDataType import ImageDataType
 
+
 class Image(object):
 
     @staticmethod
@@ -50,10 +51,47 @@ class Image(object):
         idx[axis] = slice(None, None, -1)
         return a[idx]
 
+    def __get_num_channels_and_dtype(data_type: ImageDataType):
+
+        '''
+        Returns the number of channels and the numpy data type.
+
+        Parameters
+        ----------
+        data_type : ImageDataType
+            Specifies the data type
+
+        Returns
+        -------
+        :class:`numpy.ndarray`
+        '''
+
+        # Set the number of channels and the numpy data type based on the input enum.
+        if data_type == ImageDataType.CV_8UC1.value:
+            num_channels = 1
+            np_data_type = np.uint8
+        elif data_type == ImageDataType.CV_8UC3.value:
+            num_channels = 3
+            np_data_type = np.uint8
+        elif data_type == ImageDataType.CV_32FC1.value:
+            num_channels = 1
+            np_data_type = np.float32
+        elif data_type == ImageDataType.CV_32FC3.value:
+            num_channels = 3
+            np_data_type = np.float32
+        elif data_type == ImageDataType.CV_64FC1.value:
+            num_channels = 1
+            np_data_type = np.float64
+        elif data_type == ImageDataType.CV_64FC3.value:
+            num_channels = 3
+            np_data_type = np.float64
+
+        return (num_channels, np_data_type)
+
     @staticmethod
     def get_image_array_from_row(image_binary, dimension, resolution, myformat, channel_count=1):
 
-        '''
+        """
         Get a 3D image from a row.
 
         Parameters
@@ -72,7 +110,7 @@ class Image(object):
         Returns
         -------
         :class:`numpy.ndarray`
-        '''
+        """
 
         num_cells = np.prod(resolution)
         if (myformat == '32S'):
@@ -112,7 +150,7 @@ class Image(object):
     @staticmethod
     def get_image_array(image_binaries, dimensions, resolutions, formats, n, channel_count=1):
 
-        '''
+        """
         Get an image from a fetched array.
 
         Parameters
@@ -133,7 +171,7 @@ class Image(object):
         Returns
         -------
         :class:`numpy.ndarray`
-        '''
+        """
 
         dimension = int(dimensions[n])
         resolution = np.array(struct.unpack('=%sq' % dimension, resolutions[n][0:dimension * 8]))
@@ -144,7 +182,7 @@ class Image(object):
     @staticmethod
     def convert_to_CAS_column(s):
 
-        '''
+        """
         Convert a string to CAS column name.
 
         Parameters
@@ -155,7 +193,7 @@ class Image(object):
         Returns
         -------
         :class:`str`
-        '''
+        """
 
         s = str.replace(str.replace(s, '{', '_'), '}', '_')
         return '_'+s+'_'
@@ -163,7 +201,7 @@ class Image(object):
     @staticmethod
     def fetch_image_array(imdata, n=0, qry='', image='_image_', dim='_dimension_', res='_resolution_', ctype='_channelType_', ccount=1):
 
-        '''
+        """
         Fetch image array from a CAS table.
 
         Parameters
@@ -188,7 +226,7 @@ class Image(object):
         Returns
         -------
         :class:`numpy.ndarray`
-        '''
+        """
 
         if (qry != ''):
             example_rows = imdata.query(qry).to_frame(to=n+1)
@@ -203,7 +241,7 @@ class Image(object):
     @staticmethod
     def fetch_geometry_info(imdata, n=0, qry='', posCol='_position_', oriCol='_orientation_', spaCol='_spacing_', dimCol='_dimension_'):
 
-        '''
+        """
         Fetch geometry information from a CAS table.
 
         Parameters
@@ -226,7 +264,7 @@ class Image(object):
         Returns
         -------
         :class:`tuple`, (position, orientation, spacing)
-        '''
+        """
 
         # Check if geometry info exists in CAS table query before fetching
         if not {'_position_', '_spacing_', '_orientation_'}.issubset(imdata.columns):
@@ -245,7 +283,7 @@ class Image(object):
     @staticmethod
     def get_image_array_const_ctype(image_binaries, dimensions, resolutions, ctype, n, channel_count=1):
 
-        '''
+        """
         Get an image array with a constant channel type from a CAS table.
 
         Parameters
@@ -266,7 +304,7 @@ class Image(object):
         Returns
         -------
         :class:`numpy.ndarray`
-        '''
+        """
         dimension = int(dimensions[n])
         resolution = np.array(struct.unpack('=%sq' % dimension, resolutions[n][0:dimension * 8]))
         resolution = resolution[::-1]
@@ -277,7 +315,7 @@ class Image(object):
     @staticmethod
     def convert_wide_to_numpy(wide_image) -> np.ndarray:
 
-        '''
+        """
         Convert a wide image to a numpy image array.
 
         Parameters
@@ -289,19 +327,32 @@ class Image(object):
         -------
         numpy.ndarray
 
-        '''
+        """
 
         # Get the width and height from the input buffer
-        width = np.frombuffer(wide_image[8:2*8], dtype=np.int64)[0]
-        height = np.frombuffer(wide_image[2*8:3*8], dtype=np.int64)[0]
-        data_type = np.frombuffer(wide_image[3*8:4*8], dtype=np.int64)[0]
+        width = np.frombuffer(wide_image[8:2 * 8], dtype=np.int64)[0]
+        height = np.frombuffer(wide_image[2 * 8:3 * 8], dtype=np.int64)[0]
+        data_type = np.frombuffer(wide_image[3 * 8:4 * 8], dtype=np.int64)[0]
 
-        # Set the number of channels to 1 if the image type is cv2.CV_8UC1
+        # Get the number of channels and the numpy data type
         if data_type == ImageDataType.CV_8UC1.value:
             num_channels = 1
-        # Set the number of channels to 3 if the image type is cv2.CV_8UC3
+            np_data_type = np.uint8
         elif data_type == ImageDataType.CV_8UC3.value:
             num_channels = 3
+            np_data_type = np.uint8
+        elif data_type == ImageDataType.CV_32FC1.value:
+            num_channels = 1
+            np_data_type = np.float32
+        elif data_type == ImageDataType.CV_32FC3.value:
+            num_channels = 3
+            np_data_type = np.float32
+        elif data_type == ImageDataType.CV_64FC1.value:
+            num_channels = 1
+            np_data_type = np.float64
+        elif data_type == ImageDataType.CV_64FC3.value:
+            num_channels = 3
+            np_data_type = np.float64
 
         # Return the numpy array
-        return np.frombuffer(wide_image[4*8:], dtype=np.uint8).reshape(height, width, num_channels)
+        return np.frombuffer(wide_image[4 * 8:], dtype=np_data_type).reshape(height, width, num_channels)

--- a/cvpy/image/Image.py
+++ b/cvpy/image/Image.py
@@ -51,43 +51,6 @@ class Image(object):
         idx[axis] = slice(None, None, -1)
         return a[idx]
 
-    def __get_num_channels_and_dtype(data_type: ImageDataType):
-
-        '''
-        Returns the number of channels and the numpy data type.
-
-        Parameters
-        ----------
-        data_type : ImageDataType
-            Specifies the data type
-
-        Returns
-        -------
-        :class:`numpy.ndarray`
-        '''
-
-        # Set the number of channels and the numpy data type based on the input enum.
-        if data_type == ImageDataType.CV_8UC1.value:
-            num_channels = 1
-            np_data_type = np.uint8
-        elif data_type == ImageDataType.CV_8UC3.value:
-            num_channels = 3
-            np_data_type = np.uint8
-        elif data_type == ImageDataType.CV_32FC1.value:
-            num_channels = 1
-            np_data_type = np.float32
-        elif data_type == ImageDataType.CV_32FC3.value:
-            num_channels = 3
-            np_data_type = np.float32
-        elif data_type == ImageDataType.CV_64FC1.value:
-            num_channels = 1
-            np_data_type = np.float64
-        elif data_type == ImageDataType.CV_64FC3.value:
-            num_channels = 3
-            np_data_type = np.float64
-
-        return (num_channels, np_data_type)
-
     @staticmethod
     def get_image_array_from_row(image_binary, dimension, resolution, myformat, channel_count=1):
 

--- a/cvpy/tests/test_image.py
+++ b/cvpy/tests/test_image.py
@@ -27,28 +27,91 @@ import numpy as np
 from cvpy.image.Image import Image
 from cvpy.base.ImageDataType import ImageDataType
 
-def create_numpy_array_and_wide_image(image, num_channels):
+
+def load(self, path):
+    self.s = swat.CAS(self.casHost, self.casPort, self.username, self.password)
+    self.s.loadactionset('image')
+
+    # Add caslib
+    self.s.addcaslib(name='dlib', activeOnAdd=False, path=self.dataPath, dataSource='PATH', subdirectories=True)
+
+    # Load the image
+    image = self.s.CASTable('image', replace=True)
+    self.s.image.loadImages(path=path,
+                            casOut=dict(name='image', replace='TRUE'),
+                            addColumns={"WIDTH", "HEIGHT"},
+                            caslib='dlib',
+                            decode=True)
+    return image
+
+
+def rescale(self, image, rescale_type):
+
+    # Determine the desired rescale type
+    if rescale_type == ImageDataType.CV_8UC1.value or rescale_type == ImageDataType.CV_8UC3.value:
+        rescale_params = "TO_8U"
+    elif rescale_type == ImageDataType.CV_32FC1.value or rescale_type == ImageDataType.CV_32FC3.value:
+        rescale_params = "TO_32F"
+    elif rescale_type == ImageDataType.CV_64FC1.value or rescale_type == ImageDataType.CV_64FC3.value:
+        rescale_params = "TO_64F"
+
+    # Rescale the image
+    self.s.image.processimages(
+        table=image,
+        casout=image,
+        steps=[
+            {
+                'step':
+                    {
+                        'stepType': 'RESCALE',
+                        'type': rescale_params
+                    }
+            }
+        ],
+        copyVars = {"_width_", "_height_"},
+        decode=True
+    )
+
+    return image
+
+
+def create_numpy_array_and_wide_image(image, num_channels, data_type):
     # Get the image data
     image_rows = image.to_frame()
     image_binary = image_rows['_image_'][0]
     width = image_rows['_width_'][0]
     height = image_rows['_height_'][0]
 
-    # Create the original numpy image array
-    image_array = np.array(bytearray(image_binary[0:(width * height * num_channels)])).astype(np.uint8)
-    numpy_image_array = np.reshape(image_array, (width, height, num_channels))
+    # Get the number of channels and the numpy data type
+    if data_type == ImageDataType.CV_8UC1.value:
+        num_channels = 1
+        np_data_type = np.uint8
+    elif data_type == ImageDataType.CV_8UC3.value:
+        num_channels = 3
+        np_data_type = np.uint8
+    elif data_type == ImageDataType.CV_32FC1.value:
+        num_channels = 1
+        np_data_type = np.float32
+    elif data_type == ImageDataType.CV_32FC3.value:
+        num_channels = 3
+        np_data_type = np.float32
+    elif data_type == ImageDataType.CV_64FC1.value:
+        num_channels = 1
+        np_data_type = np.float64
+    elif data_type == ImageDataType.CV_64FC3.value:
+        num_channels = 3
+        np_data_type = np.float64
 
-    # Get the data type of the image from num_channels
-    if num_channels == 1:
-        data_type = ImageDataType.CV_8UC1.value
-    elif num_channels == 3:
-        data_type = ImageDataType.CV_8UC3.value
+    # Create the original numpy image array
+    image_array = np.array(bytearray(image_binary[0:(width * height * num_channels)])).astype(np_data_type)
+    numpy_image_array = np.reshape(image_array, (width, height, num_channels))
 
     # Convert the numpy array to a wide image
     wide_prefix = np.array([-1, height, width, data_type], dtype=np.int64)
 
     # Return both the array and the wide image
-    return (numpy_image_array, (wide_prefix.tobytes() + numpy_image_array.tobytes()))
+    return numpy_image_array, (wide_prefix.tobytes() + numpy_image_array.tobytes())
+
 
 class TestImage(unittest.TestCase):
 
@@ -217,23 +280,14 @@ class TestImage(unittest.TestCase):
         # Close the connection
         self.s.close()
 
-    def test_convert_wide_to_numpy_3_channel(self):
-        self.s = swat.CAS(self.casHost, self.casPort, self.username, self.password)
-        self.s.loadactionset('image')
-
-        # Add caslib
-        self.s.addcaslib(name='dlib', activeOnAdd=False, path=self.dataPath, dataSource='PATH', subdirectories=True)
-
-        # Load the image
-        image = self.s.CASTable('image', replace=True)
-        self.s.image.loadImages(path='images/Sas_c.jpg',
-                                casOut=dict(name='image', replace='TRUE'),
-                                addColumns={"WIDTH", "HEIGHT"},
-                                caslib='dlib',
-                                decode=True)
+    # Test convert_wide_to_numpy() function for a CV_8UC3 image
+    def test_convert_wide_to_numpy_CV_8UC3(self):
+        # Load and rescale the input image to the desired type
+        image = load(self, 'images/Sas_c.jpg')
+        image = rescale(self, image, ImageDataType.CV_8UC3.value)
 
         # Use the image data to create the original numpy array and the wide image to be converted
-        (numpy_image_array, wide_byte_buffer) = create_numpy_array_and_wide_image(image, 3)
+        (numpy_image_array, wide_byte_buffer) = create_numpy_array_and_wide_image(image, 3, ImageDataType.CV_8UC3.value)
 
         # Use the convert_wide_to_numpy() function to convert the wide image back to numpy
         output_array = Image.convert_wide_to_numpy(wide_byte_buffer)
@@ -244,23 +298,14 @@ class TestImage(unittest.TestCase):
         # Close the connection
         self.s.close()
 
-    def test_convert_wide_to_numpy_1_channel(self):
-        self.s = swat.CAS(self.casHost, self.casPort, self.username, self.password)
-        self.s.loadactionset('image')
-
-        # Add caslib
-        self.s.addcaslib(name='dlib', activeOnAdd=False, path=self.dataPath, dataSource='PATH', subdirectories=True)
-
-        # Load the image
-        image = self.s.CASTable('image', replace=True)
-        self.s.image.loadImages(path='unittest/gray_3x3.png',
-                                casOut=dict(name='image', replace='TRUE'),
-                                addColumns={"WIDTH", "HEIGHT"},
-                                caslib='dlib',
-                                decode=True)
+    # Test convert_wide_to_numpy() function for a CV_8UC1 image
+    def test_convert_wide_to_numpy_CV_8UC1(self):
+        # Load and rescale the input image to the desired type
+        image = load(self, 'unittest/gray_3x3.png')
+        image = rescale(self, image, ImageDataType.CV_8UC1.value)
 
         # Use the image data to create the original numpy array and the wide image to be converted
-        (numpy_image_array, wide_byte_buffer) = create_numpy_array_and_wide_image(image, 1)
+        (numpy_image_array, wide_byte_buffer) = create_numpy_array_and_wide_image(image, 1, ImageDataType.CV_8UC1.value)
 
         # Use the convert_wide_to_numpy() function to convert the wide image back to numpy
         output_array = Image.convert_wide_to_numpy(wide_byte_buffer)
@@ -270,6 +315,79 @@ class TestImage(unittest.TestCase):
 
         # Close the connection
         self.s.close()
+
+    # Test convert_wide_to_numpy() function for a CV_32FC1 image
+    def test_convert_wide_to_numpy_CV_32FC1(self):
+        # Load and rescale the input image to the desired type
+        image = load(self, 'unittest/gray_3x3.png')
+        image = rescale(self, image, ImageDataType.CV_32FC1.value)
+
+        # Use the image data to create the original numpy array and the wide image to be converted
+        (numpy_image_array, wide_byte_buffer) = create_numpy_array_and_wide_image(image, 1, ImageDataType.CV_32FC1.value)
+
+        # Use the convert_wide_to_numpy() function to convert the wide image back to numpy
+        output_array = Image.convert_wide_to_numpy(wide_byte_buffer)
+
+        # Compare these arrays to make sure they are equal
+        self.assertTrue(np.array_equal(numpy_image_array, output_array))
+
+        # Close the connection
+        self.s.close()
+
+    # Test convert_wide_to_numpy() function for a CV_32FC3 image
+    def test_convert_wide_to_numpy_CV_32FC3(self):
+        # Load and rescale the input image to the desired type
+        image = load(self, 'images/Sas_c.jpg')
+        image = rescale(self, image, ImageDataType.CV_32FC3.value)
+
+        # Use the image data to create the original numpy array and the wide image to be converted
+        (numpy_image_array, wide_byte_buffer) = create_numpy_array_and_wide_image(image, 3, ImageDataType.CV_32FC3.value)
+
+        # Use the convert_wide_to_numpy() function to convert the wide image back to numpy
+        output_array = Image.convert_wide_to_numpy(wide_byte_buffer)
+
+        # Compare these arrays to make sure they are equal
+        self.assertTrue(np.array_equal(numpy_image_array, output_array))
+
+        # Close the connection
+        self.s.close()
+
+    # Test convert_wide_to_numpy() function for a CV_64FC1 image
+    def test_convert_wide_to_numpy_CV_64FC1(self):
+        # Load and rescale the input image to the desired type
+        image = load(self, 'unittest/gray_3x3.png')
+        image = rescale(self, image, ImageDataType.CV_64FC1.value)
+
+        # Use the image data to create the original numpy array and the wide image to be converted
+        (numpy_image_array, wide_byte_buffer) = create_numpy_array_and_wide_image(image, 1, ImageDataType.CV_64FC1.value)
+
+        # Use the convert_wide_to_numpy() function to convert the wide image back to numpy
+        output_array = Image.convert_wide_to_numpy(wide_byte_buffer)
+
+        # Compare these arrays to make sure they are equal
+        self.assertTrue(np.array_equal(numpy_image_array, output_array))
+
+        # Close the connection
+        self.s.close()
+
+    # Test convert_wide_to_numpy() function for a CV_64FC3 image
+    def test_convert_wide_to_numpy_CV_64FC3(self):
+        # Load and rescale the input image to the desired type
+        image = load(self, 'images/Sas_c.jpg')
+        image = rescale(self, image, ImageDataType.CV_64FC3.value)
+
+        # Use the image data to create the original numpy array and the wide image to be converted
+        (numpy_image_array, wide_byte_buffer) = create_numpy_array_and_wide_image(image, 3, ImageDataType.CV_64FC3.value)
+
+        # Use the convert_wide_to_numpy() function to convert the wide image back to numpy
+        output_array = Image.convert_wide_to_numpy(wide_byte_buffer)
+
+        # Compare these arrays to make sure they are equal
+        self.assertTrue(np.array_equal(numpy_image_array, output_array))
+
+        # Close the connection
+        self.s.close()
+
 
 if __name__ == '__main__':
     if len(sys.argv) > 1:


### PR DESCRIPTION
In this commit, float images are supported in the convert_wide_to_numpy() function in CVPy. Test cases are added for all of the new supported data types.