### PR TITLE
Fix a bug in resume function leading to null project_id

### DIFF
--- a/cvpy/annotation/cvat/CVATProject.py
+++ b/cvpy/annotation/cvat/CVATProject.py
@@ -266,7 +266,7 @@ class CVATProject(Project):
         project = CVATProject()
 
         project.url = project_dict.get('url')
-        project.project_id = project_dict.get('id')
+        project.project_id = project_dict.get('project_id')
         project.project_name = project_dict.get('project_name')
         project.project_version = project_dict.get('project_version')
         project.credentials = Credentials.from_dict(project_dict.get('credentials'))

--- a/cvpy/tests/test_cvat_project.py
+++ b/cvpy/tests/test_cvat_project.py
@@ -7,7 +7,6 @@ from http import HTTPStatus
 import requests
 import swat
 import xmlrunner
-
 from cvpy.annotation.base.AnnotationLabel import AnnotationLabel
 from cvpy.annotation.base.AnnotationType import AnnotationType
 from cvpy.annotation.base.Credentials import Credentials
@@ -197,6 +196,7 @@ class TestCVATProject(unittest.TestCase):
         # Verify all project attributes are set correctly
         assert cvat_project.project_version == 1
         assert cvat_project.project_name == 'MyDemoProject'
+        assert cvat_project.project_id == 285
         assert cvat_project.annotation_type == AnnotationType.OBJECT_DETECTION
         assert cvat_project.credentials.username is None
         assert cvat_project.credentials.password is None


### PR DESCRIPTION
This commit fixes a bug in CVATProject.resume function due to which the project_id was not getting set correctly after a project is resumed.